### PR TITLE
Fix OLS failing for univariate no-intercept case

### DIFF
--- a/test/models/simple-regression-univariate-no-intercept-test.js
+++ b/test/models/simple-regression-univariate-no-intercept-test.js
@@ -1,0 +1,23 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat');
+
+require('../env.js');
+
+suite.addBatch({
+  'univariate no-intercept regression': {
+    'topic': function() {
+      return jStat;
+    },
+    'array call': function(jStat) {
+      var exog = [[0], [4], [2], [3]];
+      var endog = [1, 9, 5, 7];
+      var model = jStat.models.ols(endog,exog);
+      var tol   = 0.00000001;
+      assert.epsilon(tol, model.coef[0], 2.310344828);
+      assert.epsilon(tol, model.t.se[0], 0.117781043);
+    }
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
The OLS model fails in the univariate no-intercept case, i.e. with a 1xN design matrix, throwing an exception out of `sub_regress` because of an attempted QR decomposition of an empty matrix object.

This adds a test reproducing such a failure, and a fix, by simply returning an empty array from `sub_regress` (there is no sub-regression to be performed).

The fix causes a degenerate t-test result object to be returned. Maybe there is something more useful to be done about that, but all that's done about it here is to compute the standard error for the (single) coefficient being returned, and place it in the `model.t.se` array (which would otherwise be empty).